### PR TITLE
Add PATH to Zsh in docs for newer macOSs

### DIFF
--- a/docs/_docs/installation/macos.md
+++ b/docs/_docs/installation/macos.md
@@ -30,7 +30,14 @@ brew install ruby
 Add the brew ruby path to your shell configuration:
 
 ```bash
+# MacOS Catalina (10.15) users and newer
+echo 'export PATH="/usr/local/opt/ruby/bin:$PATH"' >> ~/.zshenv
+
+# MacOS Mojave (10.14) users and older
 echo 'export PATH="/usr/local/opt/ruby/bin:$PATH"' >> ~/.bash_profile
+
+# Unsure which version of macOS you are using? Try
+sw_vers -productVersion 
 ```
 
 Relaunch your terminal and check your Ruby setup:

--- a/docs/_docs/installation/macos.md
+++ b/docs/_docs/installation/macos.md
@@ -105,7 +105,14 @@ ruby -v
 Append your path file with the following, replacing the `X.X` with the first two digits of your Ruby version:
 
 ```bash
+# MacOS Catalina (10.15) users and newer
+echo 'export PATH="$HOME/.gem/ruby/X.X.0/bin:$PATH"' >> ~/.zshenv
+
+# MacOS Mojave (10.14) users and older
 echo 'export PATH="$HOME/.gem/ruby/X.X.0/bin:$PATH"' >> ~/.bash_profile
+
+# Unsure which version of macOS you are using? Try
+sw_vers -productVersion 
 ```
 
 Check that `GEM PATHS:` points to your home directory:


### PR DESCRIPTION
Apple switched the default shell to Zsh with Catalina, so adding the ruby PATH in .bash_profile is increasingly now the legacy approach. It will not have effect for relevant users and will prevent them from continuing with the instructions. 

This commit adds instructions to echo the PATH to .zshenv (the Zsh equivalent of .bash_profile) as well as to check which version of macOS is running for those who are unsure.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

I've updated the macOS installation documentation to make them work for users of Catalina and newer versions of macOS, for whom the default shell is no longer bash but is now zsh, and so for whom adding the ruby PATH to .bash_profile will not have any effect 

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
